### PR TITLE
Allow cores with size > 100MiB using Git-LFS

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Get current date

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Get current date

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/build_and_update_addons.py
+++ b/build_and_update_addons.py
@@ -73,18 +73,18 @@ script_settings['buildbot_settings']['bb_urls'] = [ 'http://buildbot.libretro.co
 													]
 
 #To be updated based on what works and what doesn't at some point at the platform level
-script_settings['buildbot_settings']['dont_install_these_cores'] = [script_settings['ignore_these_cores_common']+['mame_libretro'], #OSX x86_64
+script_settings['buildbot_settings']['dont_install_these_cores'] = [script_settings['ignore_these_cores_common'], #OSX x86_64
 																# [x for x in script_settings['all_cores_common'] if x not in script_settings['android_cores_test']], #Android 64
 																# [x for x in script_settings['all_cores_common'] if x not in script_settings['android_cores_test']], #Android v7a
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #Android 64
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #Android v7a
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #Linux x86_64
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #Windows x86, MAME is too big for github
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #Windows x86_64, MAME is too big for github
+																script_settings['ignore_these_cores_common'], #Android 64
+																script_settings['ignore_these_cores_common'], #Android v7a
+																script_settings['ignore_these_cores_common'], #Linux x86_64
+																script_settings['ignore_these_cores_common'], #Windows x86
+																script_settings['ignore_these_cores_common'], #Windows x86_64
 																# [x for x in script_settings['all_cores_common'] if x not in script_settings['cores_test']], #LE x86_64
-																# [x for x in script_settings['all_cores_common'] if x not in script_settings['cores_test']], #LE ARMHF, MAME is too big for github
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #LE x86_64
-																script_settings['ignore_these_cores_common']+['mame_libretro'], #LE ARMHF, MAME is too big for github
+																# [x for x in script_settings['all_cores_common'] if x not in script_settings['cores_test']], #LE ARMHF
+																script_settings['ignore_these_cores_common'], #LE x86_64
+																script_settings['ignore_these_cores_common'], #LE ARMHF
 																]
 
 script_settings['buildbot_settings']['build_platform_addons'] = [True,


### PR DESCRIPTION
Fix #12.

Allow cores > 100MiB by using Git-LFS for them.

*Note: This solution is still limited by some GiHub quotas and should be OK with only a few cores using Git-LFS (Currently, only a singe file). If not sufficient, another solution with no limitation can be to upload zip files are GitHub Release artifacts, but this will require more changes.*