### PR TITLE
Fix add-on IDs

### DIFF
--- a/repository.kodi_libretro_buildbot_game_addons_le_armhf/addon.xml
+++ b/repository.kodi_libretro_buildbot_game_addons_le_armhf/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="repository.kodi_libretro_buildbot_game_addons" name="Kodi Libretro Buildbot Game Addons LE ARMHF" version="1.0.1" provider-name="zachmorris">
+<addon id="repository.kodi_libretro_buildbot_game_addons_le_armhf" name="Kodi Libretro Buildbot Game Addons LE ARMHF" version="1.0.2" provider-name="zachmorris">
     <requires>
         <import addon="xbmc.addon" version="12.0.0"/>
     </requires>

--- a/repository.kodi_libretro_buildbot_game_addons_le_generic/addon.xml
+++ b/repository.kodi_libretro_buildbot_game_addons_le_generic/addon.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="repository.kodi_libretro_buildbot_game_addons" name="Kodi Libretro Buildbot Game Addons LE Generic" version="1.0.1" provider-name="zachmorris">
+<addon id="repository.kodi_libretro_buildbot_game_addons_le_generic" name="Kodi Libretro Buildbot Game Addons LE Generic" version="1.0.2" provider-name="zachmorris">
     <requires>
         <import addon="xbmc.addon" version="12.0.0"/>
     </requires>


### PR DESCRIPTION
## Description

This PR fixes the add-on IDs of the two LibreELEC repos. As a result, when both repos are present (such as in my RP builds), only armhf is shown.

## Motivation and context

I noticed that they were the same IDs (and didn't match the foldernames, which also define the add-on ID).

## How has this been tested?

Before, only armhf is shown:

![Screenshot from 2024-05-26 13-47-09](https://github.com/zach-morris/kodi_libretro_buildbot_game_addons/assets/531482/bc6391a3-00ee-453c-bbe4-42d0c732f339)

After, both armhf and generic are shown:

![Screenshot from 2024-05-26 13-48-01](https://github.com/zach-morris/kodi_libretro_buildbot_game_addons/assets/531482/861e5511-dc86-45f5-931e-2ccbf3bfe648)

