### PR TITLE
skip broken indexed files ie: ".zip"

### DIFF
--- a/lib/bb_utils.py
+++ b/lib/bb_utils.py
@@ -142,7 +142,8 @@ def read_text_url(url_in):
 	return r.text
 
 def parse_index_data(index_text_in):
-	split_text = [x for x in sorted(index_text_in.split('\n')) if '.zip' in x.lower()]
+	# date hash filename\n...
+	split_text = [x for x in sorted(index_text_in.split('\n')) if '.zip' in x.lower() and x.count(" ") >= 2]
 	index_data_out = dict()
 	index_data_out['filename'] = [x.split(' ')[-1].strip() for x in split_text]
 	index_data_out['filename_no_ext'] = [x.split('.')[0] for x in index_data_out['filename']]


### PR DESCRIPTION
http://buildbot.libretro.com/nightly/windows/x86_64/latest/.index-extended

provides output as below which causes script to crash

2025-02-03 49b002a9 mgba_libretro.dll.zip
.zip
2025-02-03 8aba3318 dice_libretro.dll.zip
2025-02-03 4adb2851 mame2010_libretro.dll.zip

This requires each entry to ahve at least 2 spaces so that script works as intended.